### PR TITLE
Fix task input UI not hiding after task submission

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -629,7 +629,7 @@ function App() {
             return;
         }
         setTasks(updatedTasks);
-        setStudyPlans(plans);
+        setStudyPlans(newPlans);
         setShowTaskInput(false);
         setLastPlanStaleReason("task");
     };

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -159,6 +159,8 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
       maxSessionLength: 2,
       isOneTimeTask: false,
     });
+    // Hide the form after successful submission
+    onCancel?.();
   };
 
   const handleTimeEstimationUpdate = (hours: string, minutes: string, taskType: string) => {


### PR DESCRIPTION
## Purpose
Fix the issue where the add task UI remains visible after successfully adding a task through the task input form. The user reported that the task input interface doesn't disappear when a task is added, creating a poor user experience.

## Code changes
- **TaskInputSimplified.tsx**: Added `onCancel?.()` call after successful form submission to hide the task input form
- **App.tsx**: Fixed variable reference from `plans` to `newPlans` in the `setStudyPlans` call to ensure proper state updates

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0b12b14497594d1e9903315a50a1b63a/mystic-zone)

👀 [Preview Link](https://0b12b14497594d1e9903315a50a1b63a-mystic-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b12b14497594d1e9903315a50a1b63a</projectId>-->
<!--<branchName>mystic-zone</branchName>-->