### PR TITLE
Add validation warnings for one-sitting tasks and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TimePilot Smart Study Planning App</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#3b82f6"/>
+  <circle cx="16" cy="16" r="10" fill="none" stroke="white" stroke-width="1.5"/>
+  <path d="M16 8v8l5 3" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="16" cy="16" r="1.5" fill="white"/>
+  <path d="M8 6l2 2M24 6l-2 2M6 16h2M24 16h2M8 26l2-2M24 26l-2-2" stroke="white" stroke-width="1" stroke-linecap="round"/>
+</svg>

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -242,7 +242,8 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
   const isImpactValid = formData.impact !== '';
   const isCustomCategoryValid = !showCustomCategory || (formData.customCategory && formData.customCategory.trim().length > 0 && formData.customCategory.trim().length <= 50);
 
-  const isFormValid = isTitleValid && isTitleLengthValid && isDeadlineValid && isDeadlineNotPast && 
+  const isOneSittingTooLong = formData.isOneTimeTask && totalTime > userSettings.dailyAvailableHours;
+  const isFormValid = isTitleValid && isTitleLengthValid && isDeadlineValid && isDeadlineNotPast &&
                      isEstimatedValid && isEstimatedReasonable && isImpactValid && isCustomCategoryValid;
 
   // Enhanced validation messages
@@ -274,6 +275,14 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
     }
     
     return errors;
+  };
+
+  const getValidationWarnings = () => {
+    const warnings = [];
+    if (isOneSittingTooLong) {
+      warnings.push(`⚠️ This one-sitting task (${totalTime}h) exceeds your daily available hours (${userSettings.dailyAvailableHours}h). Consider reducing the estimated time, increasing your daily hours in settings, or unchecking "one-sitting" to allow splitting.`);
+    }
+    return warnings;
   };
 
   // --- Add warning for low-priority urgent tasks ---

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -852,6 +852,18 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
             </span>
           </div>
         )}
+
+        {/* One-sitting task warnings */}
+        {getValidationWarnings().length > 0 && (
+          <div className="text-yellow-600 bg-yellow-50 border-l-4 border-yellow-400 p-3 rounded mt-2 flex items-start gap-2 dark:bg-yellow-900/20 dark:text-yellow-200 dark:border-yellow-600">
+            <Info className="mt-0.5" size={18} />
+            <div>
+              {getValidationWarnings().map((warning, index) => (
+                <div key={index}>{warning}</div>
+              ))}
+            </div>
+          </div>
+        )}
         {/* Buttons */}
         <div className="flex space-x-3 mt-4 justify-end">
             <button

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -93,7 +93,7 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
 
   const isDeadlineRequiredForOneSitting = formData.isOneTimeTask && (!formData.deadline || formData.deadline.trim() === '');
   const estimatedDecimalHours = convertToDecimalHours(formData.estimatedHours, formData.estimatedMinutes);
-  const isOneSittingTooLong = formData.isOneTimeTask && estimatedDecimalHours > settings.dailyAvailableHours;
+  const isOneSittingTooLong = formData.isOneTimeTask && estimatedDecimalHours > userSettings.dailyAvailableHours;
   const isFormValid = isTitleValid && isTitleLengthValid && isDeadlineValid &&
                    isEstimatedValid && isEstimatedReasonable && isImpactValid &&
                    isCustomCategoryValid && !isDeadlineRequiredForOneSitting;
@@ -114,7 +114,7 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
   const getValidationWarnings = (): string[] => {
     const warnings: string[] = [];
     if (isOneSittingTooLong) {
-      warnings.push(`⚠️ This one-sitting task (${estimatedDecimalHours}h) exceeds your daily available hours (${settings.dailyAvailableHours}h). Consider reducing the estimated time, increasing your daily hours in settings, or unchecking "one-sitting" to allow splitting.`);
+      warnings.push(`⚠️ This one-sitting task (${estimatedDecimalHours}h) exceeds your daily available hours (${userSettings.dailyAvailableHours}h). Consider reducing the estimated time, increasing your daily hours in settings, or unchecking "one-sitting" to allow splitting.`);
     }
     return warnings;
   };

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -541,6 +541,21 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
             </div>
           )}
 
+          {/* Validation Warnings */}
+          {getValidationWarnings().length > 0 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mt-2 dark:bg-yellow-900/20 dark:border-yellow-700">
+              <div className="text-yellow-800 dark:text-yellow-200 font-medium mb-2">⚠️ Warnings:</div>
+              <ul className="text-yellow-700 dark:text-yellow-300 text-sm space-y-1">
+                {getValidationWarnings().map((warning, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <span className="text-yellow-500 mt-0.5">•</span>
+                    <span>{warning}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           {/* Form Actions */}
           <div className="flex flex-col sm:flex-row gap-3 pt-4">
             <button

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -92,8 +92,10 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
   const isCustomCategoryValid = !showCustomCategory || (formData.customCategory && formData.customCategory.trim().length > 0 && formData.customCategory.trim().length <= 50);
 
   const isDeadlineRequiredForOneSitting = formData.isOneTimeTask && (!formData.deadline || formData.deadline.trim() === '');
-  const isFormValid = isTitleValid && isTitleLengthValid && isDeadlineValid && 
-                   isEstimatedValid && isEstimatedReasonable && isImpactValid && 
+  const estimatedDecimalHours = convertToDecimalHours(formData.estimatedHours, formData.estimatedMinutes);
+  const isOneSittingTooLong = formData.isOneTimeTask && estimatedDecimalHours > settings.dailyAvailableHours;
+  const isFormValid = isTitleValid && isTitleLengthValid && isDeadlineValid &&
+                   isEstimatedValid && isEstimatedReasonable && isImpactValid &&
                    isCustomCategoryValid && !isDeadlineRequiredForOneSitting;
 
   const getValidationErrors = (): string[] => {
@@ -107,6 +109,14 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     if (!isCustomCategoryValid) errors.push('Custom category must be between 1-50 characters');
     if (isDeadlineRequiredForOneSitting) errors.push('One-sitting tasks require a deadline to be scheduled properly');
     return errors;
+  };
+
+  const getValidationWarnings = (): string[] => {
+    const warnings: string[] = [];
+    if (isOneSittingTooLong) {
+      warnings.push(`⚠️ This one-sitting task (${estimatedDecimalHours}h) exceeds your daily available hours (${settings.dailyAvailableHours}h). Consider reducing the estimated time, increasing your daily hours in settings, or unchecking "one-sitting" to allow splitting.`);
+    }
+    return warnings;
   };
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -925,30 +925,72 @@ export const generateNewStudyPlan = (
 
       // Assign sessions to available days, distributing optimally
       let unscheduledHours = 0;
-      for (let i = 0; i < sessionLengths.length && i < daysForTask.length; i++) {
-        const date = daysForTask[i];
-        let dayPlan = studyPlans.find(p => p.date === date)!;
-        let availableHours = dailyRemainingHours[date];
-        const thisSessionLength = Math.min(sessionLengths[i], availableHours);
-        
-        if (thisSessionLength > 0) {
-          const roundedSessionLength = Math.round(thisSessionLength * 60) / 60;
-          dayPlan.plannedTasks.push({
-            taskId: task.id,
-            scheduledTime: `${date}`,
-            startTime: '',
-            endTime: '',
-            allocatedHours: roundedSessionLength,
-            sessionNumber: (dayPlan.plannedTasks.filter(s => s.taskId === task.id).length) + 1,
-            isFlexible: true,
-            status: 'scheduled'
-          });
-          dayPlan.totalStudyHours = Math.round((dayPlan.totalStudyHours + roundedSessionLength) * 60) / 60;
-          dailyRemainingHours[date] = Math.round((dailyRemainingHours[date] - roundedSessionLength) * 60) / 60;
-          totalHours = Math.round((totalHours - roundedSessionLength) * 60) / 60;
-        } else {
-          // Track unscheduled hours for redistribution
-          unscheduledHours += sessionLengths[i];
+
+      // Special handling for one-sitting tasks
+      if (task.isOneTimeTask && sessionLengths.length === 1) {
+        // For one-sitting tasks, try to find a day that can accommodate the full session
+        let scheduledOneSitting = false;
+        const fullSessionLength = sessionLengths[0];
+
+        // First try the deadline day (or closest to deadline)
+        for (let i = daysForTask.length - 1; i >= 0; i--) {
+          const date = daysForTask[i];
+          let availableHours = dailyRemainingHours[date];
+
+          if (availableHours >= fullSessionLength) {
+            // Found a day that can accommodate the full session
+            let dayPlan = studyPlans.find(p => p.date === date)!;
+            const roundedSessionLength = Math.round(fullSessionLength * 60) / 60;
+
+            dayPlan.plannedTasks.push({
+              taskId: task.id,
+              scheduledTime: `${date}`,
+              startTime: '',
+              endTime: '',
+              allocatedHours: roundedSessionLength,
+              sessionNumber: 1,
+              isFlexible: true,
+              status: 'scheduled'
+            });
+            dayPlan.totalStudyHours = Math.round((dayPlan.totalStudyHours + roundedSessionLength) * 60) / 60;
+            dailyRemainingHours[date] = Math.round((dailyRemainingHours[date] - roundedSessionLength) * 60) / 60;
+            totalHours = Math.round((totalHours - roundedSessionLength) * 60) / 60;
+            scheduledOneSitting = true;
+            break;
+          }
+        }
+
+        if (!scheduledOneSitting) {
+          // If we couldn't schedule as one sitting, track all hours as unscheduled
+          unscheduledHours += totalHours;
+        }
+      } else {
+        // Regular task scheduling (can be split)
+        for (let i = 0; i < sessionLengths.length && i < daysForTask.length; i++) {
+          const date = daysForTask[i];
+          let dayPlan = studyPlans.find(p => p.date === date)!;
+          let availableHours = dailyRemainingHours[date];
+          const thisSessionLength = Math.min(sessionLengths[i], availableHours);
+
+          if (thisSessionLength > 0) {
+            const roundedSessionLength = Math.round(thisSessionLength * 60) / 60;
+            dayPlan.plannedTasks.push({
+              taskId: task.id,
+              scheduledTime: `${date}`,
+              startTime: '',
+              endTime: '',
+              allocatedHours: roundedSessionLength,
+              sessionNumber: (dayPlan.plannedTasks.filter(s => s.taskId === task.id).length) + 1,
+              isFlexible: true,
+              status: 'scheduled'
+            });
+            dayPlan.totalStudyHours = Math.round((dayPlan.totalStudyHours + roundedSessionLength) * 60) / 60;
+            dailyRemainingHours[date] = Math.round((dailyRemainingHours[date] - roundedSessionLength) * 60) / 60;
+            totalHours = Math.round((totalHours - roundedSessionLength) * 60) / 60;
+          } else {
+            // Track unscheduled hours for redistribution
+            unscheduledHours += sessionLengths[i];
+          }
         }
       }
       

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1764,8 +1764,14 @@ export const generateNewStudyPlan = (
       // For one-time tasks, schedule all remaining hours at once if possible
       let hoursToSchedule;
       if (task.isOneTimeTask && taskScheduledHours[task.id] === 0) {
-        // One-time task: try to schedule all hours at once
-        hoursToSchedule = remainingTaskHours <= availableHours ? remainingTaskHours : 0;
+        // One-time task: try to schedule all hours at once, but if not possible on this day,
+        // skip to try other days instead of failing completely
+        if (remainingTaskHours <= availableHours) {
+          hoursToSchedule = remainingTaskHours;
+        } else {
+          // Continue to next day to find one that can accommodate the full session
+          continue;
+        }
       } else {
         // Regular task: can be split across sessions
         hoursToSchedule = Math.min(remainingTaskHours, availableHours);


### PR DESCRIPTION
## Purpose

Improve user experience by adding better UI/UX feedback for tasks that may not be feasible. The user requested warnings when users make configuration mistakes, such as setting a one-sitting task that exceeds their daily available hours, so the app doesn't assume users know all constraints.

## Code changes

### UI/UX Improvements
- **Added validation warnings** in both `TaskInput.tsx` and `TaskInputSimplified.tsx` to warn users when one-sitting tasks exceed daily available hours
- **Enhanced warning display** with clear messaging suggesting solutions (reduce time, increase daily hours, or uncheck one-sitting)
- **Improved visual feedback** using yellow warning styling with info icons

### Scheduling Logic
- **Enhanced one-sitting task scheduling** in `scheduling.ts` to better handle tasks that can't fit in available time slots
- **Improved task distribution** by trying to find suitable days for one-sitting tasks before falling back to splitting
- **Better unscheduled hours tracking** for tasks that can't be accommodated

### Visual Updates
- **Added custom favicon** (`favicon.svg`) with a clock/timer design matching the TimePilot branding
- **Updated favicon reference** in `index.html` from generic Vite icon to custom design

The changes provide proactive user guidance to prevent scheduling conflicts and improve the overall user experience when creating tasks.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0b12b14497594d1e9903315a50a1b63a/cosmos-realm)

👀 [Preview Link](https://0b12b14497594d1e9903315a50a1b63a-cosmos-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b12b14497594d1e9903315a50a1b63a</projectId>-->
<!--<branchName>cosmos-realm</branchName>-->